### PR TITLE
Use the macro "hack" for 1.30.0 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "utf16_lit"
 description = "Proc-macro to make utf-16 literals."
-version = "1.0.1-alpha.0"
+version = "1.0.1-alpha.1"
 repository = "https://github.com/Lokathor/utf16_lit"
 authors = ["Lokathor <zefria@gmail.com>"]
 edition = "2018"
 license = "Zlib OR Apache-2.0 OR MIT"
 
-[lib]
-proc-macro = true
+[dependencies]
+utf16_lit_impl = { version = "0.1.0", path = "./utf16_lit_impl" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(bad_style)]
-
 //! Provides a proc-macro for making utf-16 literals.
 //!
 //! ```rust
@@ -23,182 +21,30 @@
 //! }
 //! ```
 
-extern crate proc_macro;
-use proc_macro::{TokenStream, TokenTree};
-
-use core::str::FromStr;
-
-use std::fmt::Write;
-
 /// Turns a string literal into a `&[u16]` literal.
 ///
 /// If you want to have a "null terminated" string (such as for some parts of
 /// Windows FFI) then you should use [`utf16_null`](utf16_null).
-#[proc_macro]
-pub fn utf16(stream: TokenStream) -> TokenStream {
-  const USAGE: &str = "Usage: utf16!(string_lit)";
-  
-  let mut tt_iter = stream.into_iter();
-  let lit = match tt_iter.next().expect(USAGE) {
-    TokenTree::Literal(lit) => lit,
-    _ => panic!(USAGE),
-  };
-  // we expect only one string literal per invocation.
-  assert!(tt_iter.next().is_none(), USAGE);
-
-  let lit_string = format!("{}", lit);
-  // right now we only support double quoted strings
-  assert!(lit_string.as_bytes().first() == Some(&b'"'), USAGE);
-  assert!(lit_string.as_bytes().last() == Some(&b'"'), USAGE);
-  let lit_str = &lit_string[1..lit_string.len()-1];
-  
-  str_to_utf16_units_tokenstream(lit_str)
+#[macro_export]
+macro_rules! utf16 {
+    ($utf8:pat) => {{
+        mod imp {
+            ::utf16_lit_impl::utf16!($utf8);
+        }
+        imp::UTF16_ENCODED
+    }}
 }
 
 /// Turns a string literal into a `&[u16]` literal with a null on the end.
 ///
 /// If you do **not** want to have a null terminator added to the string then
 /// you should use [`utf16`](utf16).
-#[proc_macro]
-pub fn utf16_null(stream: TokenStream) -> TokenStream {
-  const USAGE: &str = "Usage: utf16!(string_lit)";
-  
-  let mut tt_iter = stream.into_iter();
-  let lit = match tt_iter.next().expect(USAGE) {
-    TokenTree::Literal(lit) => lit,
-    _ => panic!(USAGE),
-  };
-  // we expect only one string literal per invocation.
-  assert!(tt_iter.next().is_none(), USAGE);
-
-  let mut lit_string = format!("{}", lit);
-  // right now we only support double quoted strings
-  assert!(lit_string.as_bytes().first() == Some(&b'"'), USAGE);
-  assert!(lit_string.as_bytes().last() == Some(&b'"'), USAGE);
-  // we need a null on the end, so we just reuse the end of this string.
-  lit_string.pop();
-  lit_string.push('\0');
-  let lit_str = &lit_string[1..];
-  
-  str_to_utf16_units_tokenstream(lit_str)
-}
-
-fn str_to_utf16_units_tokenstream(s: &str) -> TokenStream {
-  let mut encode_buf = [0_u16; 2];
-  let mut buf = String::with_capacity(s.as_bytes().len() * 8 + 10);
-  //
-  buf.push_str("&[");
-  for char_escape in CharEscapeIterator::new(s.chars()) {
-    match char_escape {
-      CharEscape::Escaped(ch) | CharEscape::Literal(ch) => {
-        for unit in ch.encode_utf16(&mut encode_buf) {
-          let _cant_fail = write!(buf, "{},", unit);
+#[macro_export]
+macro_rules! utf16_null {
+    ($utf8:pat) => {{
+        mod imp {
+            ::utf16_lit_impl::utf16_null!($utf8);
         }
-      },
-      other => panic!("Illegal character escape sequence: {:?}", other),
-    }
-  }
-  buf.push_str("]");
-  //
-  TokenStream::from_str(&buf).unwrap()
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CharEscape {
-  Literal(char),
-  Escaped(char),
-  Improper(char),
-  DanglingBackslash,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct CharEscapeIterator<I> {
-  it: I,
-}
-
-impl<I> CharEscapeIterator<I>
-where
-  I: Iterator<Item = char>,
-{
-  fn new(it: I) -> Self {
-    Self { it }
-  }
-}
-
-impl<I> Iterator for CharEscapeIterator<I>
-where
-  I: Iterator<Item = char>,
-{
-  type Item = CharEscape;
-  fn next(&mut self) -> Option<CharEscape> {
-    if let Some(ch) = self.it.next() {
-      match ch {
-        '\\' => {
-          if let Some(follow) = self.it.next() {
-            match follow {
-              '0' => Some(CharEscape::Escaped('\0')),
-              'n' => Some(CharEscape::Escaped('\n')),
-              'r' => Some(CharEscape::Escaped('\r')),
-              't' => Some(CharEscape::Escaped('\t')),
-              '\\' => Some(CharEscape::Escaped('\\')),
-              '\'' => Some(CharEscape::Escaped('\'')),
-              '"' => Some(CharEscape::Escaped('"')),
-              'x' => {
-                let mut inner = || {
-                  let d1 = self.it.next()?;
-                  let d2 = self.it.next()?;
-                  let mut temp = [0; 4];
-                  let a = u8::from_str_radix(d1.encode_utf8(&mut temp), 16).ok()?;
-                  let b = u8::from_str_radix(d2.encode_utf8(&mut temp), 16).ok()?;
-                  let c = a << 4 | b;
-                  if c < 128 {
-                    Some(CharEscape::Escaped(c as char))
-                  } else {
-                    None
-                  }
-                };
-                inner().or(Some(CharEscape::Improper('x')))
-              }
-              'u' => {
-                let mut inner = || {
-                  let open_brace = self.it.next();
-                  if open_brace != Some('{') {
-                    return None;
-                  }
-                  let mut buffer = [0_u8; 6];
-                  let mut buffer_index = 0;
-                  loop {
-                    let next_ch = self.it.next()?;
-                    if next_ch == '}' {
-                      break;
-                    } else if buffer_index >= buffer.len() {
-                      // we have to keep eating until we see '}', so for now
-                      // just signal failure and we check after the loop.
-                      buffer_index = usize::max_value();
-                    } else {
-                      buffer[buffer_index] = next_ch as u8;
-                      buffer_index += 1;
-                    }
-                  }
-                  if buffer_index == usize::max_value() {
-                    return None;
-                  }
-                  let s = core::str::from_utf8(&buffer[..buffer_index]).ok()?;
-                  let u = u32::from_str_radix(s, 16).ok()?;
-                  core::char::from_u32(u).map(CharEscape::Escaped)
-                };
-                inner().or(Some(CharEscape::Improper('u')))
-              }
-              imp => Some(CharEscape::Improper(imp)),
-            }
-          } else {
-            Some(CharEscape::DanglingBackslash)
-          }
-        }
-        other => Some(CharEscape::Literal(other)),
-      }
-    } else {
-      None
-    }
-  }
+        imp::UTF16_ENCODED
+    }}
 }

--- a/utf16_lit_impl/Cargo.toml
+++ b/utf16_lit_impl/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "utf16_lit_impl"
+version = "0.1.0"
+authors = ["Lokathor <zefria@gmail.com>"]
+edition = "2018"
+license = "Zlib OR Apache-2.0 OR MIT"
+
+[lib]
+proc-macro = true

--- a/utf16_lit_impl/src/lib.rs
+++ b/utf16_lit_impl/src/lib.rs
@@ -1,0 +1,179 @@
+#![allow(bad_style)]
+
+extern crate proc_macro;
+use proc_macro::{TokenStream, TokenTree};
+
+use core::str::FromStr;
+
+use std::fmt::Write;
+
+#[proc_macro]
+pub fn utf16(stream: TokenStream) -> TokenStream {
+  const USAGE: &str = "Usage: utf16!(string_lit)";
+  
+  let mut tt_iter = stream.into_iter();
+  let lit = match tt_iter.next().expect(USAGE) {
+    TokenTree::Group(group) => match group.stream().into_iter().next().expect(USAGE) {
+      TokenTree::Literal(lit) => lit,
+      _ => panic!(USAGE),
+    },
+    _ => panic!(USAGE),
+  };
+  // we expect only one string literal per invocation.
+  assert!(tt_iter.next().is_none(), USAGE);
+
+  let lit_string = format!("{}", lit);
+  // right now we only support double quoted strings
+  assert!(lit_string.as_bytes().first() == Some(&b'"'), USAGE);
+  assert!(lit_string.as_bytes().last() == Some(&b'"'), USAGE);
+  let lit_str = &lit_string[1..lit_string.len()-1];
+  
+  str_to_utf16_units_tokenstream(lit_str)
+}
+
+#[proc_macro]
+pub fn utf16_null(stream: TokenStream) -> TokenStream {
+  const USAGE: &str = "Usage: utf16!(string_lit)";
+  
+  let mut tt_iter = stream.into_iter();
+  let lit = match tt_iter.next().expect(USAGE) {
+    TokenTree::Group(group) => match group.stream().into_iter().next().expect(USAGE) {
+      TokenTree::Literal(lit) => lit,
+      _ => panic!(USAGE),
+    },
+    _ => panic!(USAGE),
+  };
+  // we expect only one string literal per invocation.
+  assert!(tt_iter.next().is_none(), USAGE);
+
+  let mut lit_string = format!("{}", lit);
+  // right now we only support double quoted strings
+  assert!(lit_string.as_bytes().first() == Some(&b'"'), USAGE);
+  assert!(lit_string.as_bytes().last() == Some(&b'"'), USAGE);
+  // we need a null on the end, so we just reuse the end of this string.
+  lit_string.pop();
+  lit_string.push('\0');
+  let lit_str = &lit_string[1..];
+  
+  str_to_utf16_units_tokenstream(lit_str)
+}
+
+fn str_to_utf16_units_tokenstream(s: &str) -> TokenStream {
+  let mut encode_buf = [0_u16; 2];
+  let mut buf = String::with_capacity(s.as_bytes().len() * 8 + 10);
+  //
+  buf.push_str("pub const UTF16_ENCODED: &'static [u16] = &[");
+  for char_escape in CharEscapeIterator::new(s.chars()) {
+    match char_escape {
+      CharEscape::Escaped(ch) | CharEscape::Literal(ch) => {
+        for unit in ch.encode_utf16(&mut encode_buf) {
+          let _cant_fail = write!(buf, "{},", unit);
+        }
+      },
+      other => panic!("Illegal character escape sequence: {:?}", other),
+    }
+  }
+  buf.push_str("];");
+  //
+  TokenStream::from_str(&buf).unwrap()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CharEscape {
+  Literal(char),
+  Escaped(char),
+  Improper(char),
+  DanglingBackslash,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CharEscapeIterator<I> {
+  it: I,
+}
+
+impl<I> CharEscapeIterator<I>
+where
+  I: Iterator<Item = char>,
+{
+  fn new(it: I) -> Self {
+    Self { it }
+  }
+}
+
+impl<I> Iterator for CharEscapeIterator<I>
+where
+  I: Iterator<Item = char>,
+{
+  type Item = CharEscape;
+  fn next(&mut self) -> Option<CharEscape> {
+    if let Some(ch) = self.it.next() {
+      match ch {
+        '\\' => {
+          if let Some(follow) = self.it.next() {
+            match follow {
+              '0' => Some(CharEscape::Escaped('\0')),
+              'n' => Some(CharEscape::Escaped('\n')),
+              'r' => Some(CharEscape::Escaped('\r')),
+              't' => Some(CharEscape::Escaped('\t')),
+              '\\' => Some(CharEscape::Escaped('\\')),
+              '\'' => Some(CharEscape::Escaped('\'')),
+              '"' => Some(CharEscape::Escaped('"')),
+              'x' => {
+                let mut inner = || {
+                  let d1 = self.it.next()?;
+                  let d2 = self.it.next()?;
+                  let mut temp = [0; 4];
+                  let a = u8::from_str_radix(d1.encode_utf8(&mut temp), 16).ok()?;
+                  let b = u8::from_str_radix(d2.encode_utf8(&mut temp), 16).ok()?;
+                  let c = a << 4 | b;
+                  if c < 128 {
+                    Some(CharEscape::Escaped(c as char))
+                  } else {
+                    None
+                  }
+                };
+                inner().or(Some(CharEscape::Improper('x')))
+              }
+              'u' => {
+                let mut inner = || {
+                  let open_brace = self.it.next();
+                  if open_brace != Some('{') {
+                    return None;
+                  }
+                  let mut buffer = [0_u8; 6];
+                  let mut buffer_index = 0;
+                  loop {
+                    let next_ch = self.it.next()?;
+                    if next_ch == '}' {
+                      break;
+                    } else if buffer_index >= buffer.len() {
+                      // we have to keep eating until we see '}', so for now
+                      // just signal failure and we check after the loop.
+                      buffer_index = usize::max_value();
+                    } else {
+                      buffer[buffer_index] = next_ch as u8;
+                      buffer_index += 1;
+                    }
+                  }
+                  if buffer_index == usize::max_value() {
+                    return None;
+                  }
+                  let s = core::str::from_utf8(&buffer[..buffer_index]).ok()?;
+                  let u = u32::from_str_radix(s, 16).ok()?;
+                  core::char::from_u32(u).map(CharEscape::Escaped)
+                };
+                inner().or(Some(CharEscape::Improper('u')))
+              }
+              imp => Some(CharEscape::Improper(imp)),
+            }
+          } else {
+            Some(CharEscape::DanglingBackslash)
+          }
+        }
+        other => Some(CharEscape::Literal(other)),
+      }
+    } else {
+      None
+    }
+  }
+}


### PR DESCRIPTION
The changes are fairly mechanical, just shunting the implementation into a `utf16_lit_impl` crate and reexporting them in the public interface. (The name of the branch was a mistake 🤦 )

- [ ] Update CI to enforce an MSRV
  - [ ] Decide on the crate's MSRV
  - [ ] Enable GitHub actions

Fixes #2 