### PR TITLE
Use const fn instead of proc_macro

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set Rust Version
-      run: rustup default 1.45.0
+      run: rustup default 1.46.0
     - name: Display Versions
       run: cargo --version && rustc --version
     - name: Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ repository = "https://github.com/Lokathor/utf16_lit"
 authors = ["Lokathor <zefria@gmail.com>"]
 edition = "2018"
 license = "Zlib OR Apache-2.0 OR MIT"
-
-[lib]
-proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,8 @@ macro_rules! imp {
       #[macro_export]
       macro_rules! $name {
         ($text:expr) => {{
-          // Try to avoid collisions with `text`'s scope
+          // Here we pick a name highly unlikely to exist in the scope
+          // that $text came from, which prevents a potential const eval cycle error.
           const __SWEIRFOH2387OPC: &str = $text;
           const UTF8: &str = __SWEIRFOH2387OPC;
           const UTF16: &[u16] = &{


### PR DESCRIPTION
1.46 makes `const fn` powerful enough to implement the conversion, and allows us to forgo parsing the string. It also means the crate can be used with any `expr` that evaluates to a `&str`.

Some of the std APIs that were being used aren't available yet. When they're made `const fn`s, the implementation can use them again.