### PR TITLE
Macro improvements: more hygienic robustness and remove non-static "footgun"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,29 +37,32 @@ macro_rules! imp {
         ($text:expr) => {{
           // Here we pick a name highly unlikely to exist in the scope
           // that $text came from, which prevents a potential const eval cycle error.
-          const ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF8: &str = $text;
-          const ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_LEN: usize =
-            $crate::internals::length_as_utf16(ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF8) + $n;
-          const ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF16: [u16; ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_LEN] = {
-            let mut buffer = [0u16; ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_LEN];
-            let mut bytes = ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF8.as_bytes();
-            let mut i = 0;
-            while let Some((ch, rest)) = $crate::internals::next_code_point(bytes) {
-              bytes = rest;
-              // https://doc.rust-lang.org/std/primitive.char.html#method.encode_utf16
-              if ch & 0xFFFF == ch {
-                buffer[i] = ch as u16;
-                i += 1;
-              } else {
-                let code = ch - 0x1_0000;
-                buffer[i] = 0xD800 | ((code >> 10) as u16);
-                buffer[i + 1] = 0xDC00 | ((code as u16) & 0x3FF);
-                i += 2;
+          const ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF8: &$crate::internals::core::primitive::str = $text;
+          {
+            use $crate::internals::core::prelude::v1::*;
+            const ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_LEN: usize =
+              $crate::internals::length_as_utf16(ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF8) + $n;
+            const ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF16: [u16; ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_LEN] = {
+              let mut buffer = [0u16; ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_LEN];
+              let mut bytes = ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF8.as_bytes();
+              let mut i = 0;
+              while let Some((ch, rest)) = $crate::internals::next_code_point(bytes) {
+                bytes = rest;
+                // https://doc.rust-lang.org/std/primitive.char.html#method.encode_utf16
+                if ch & 0xFFFF == ch {
+                  buffer[i] = ch as u16;
+                  i += 1;
+                } else {
+                  let code = ch - 0x1_0000;
+                  buffer[i] = 0xD800 | ((code >> 10) as u16);
+                  buffer[i + 1] = 0xDC00 | ((code as u16) & 0x3FF);
+                  i += 2;
+                }
               }
-            }
-            buffer
-          };
-          ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF16
+              buffer
+            };
+            ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF16
+          }
         }};
       }
     )*
@@ -80,8 +83,10 @@ imp! {
   utf16_null has 1 trailing zeroes
 }
 
+/// Not part of the public API.
 #[doc(hidden)]
 pub mod internals {
+  pub use ::core;
   // A const implementation of https://github.com/rust-lang/rust/blob/d902752866cbbdb331e3cf28ff6bba86ab0f6c62/library/core/src/str/mod.rs#L509-L537
   // Assumes `utf8` is a valid &str
   pub const fn next_code_point(utf8: &[u8]) -> Option<(u32, &[u8])> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![no_std]
+#![forbid(unsafe_code)]
+
 //! Provides a macro_rules for making utf-16 literals.
 //!
 //! Outputs are arrays of the correct size. Prefix the macro with `&` to make

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,9 @@
 //! ```rust
 //! use utf16_lit::{utf16, utf16_null};
 //!
-//! const EXAMPLE: &[u16] = &utf16!("example");
+//! const EXAMPLE: &[u16] = utf16!("example");
 //!
-//! const EXAMPLE_NULL: &[u16] = &utf16_null!("example");
+//! const EXAMPLE_NULL: &[u16] = utf16_null!("example");
 //!
 //! fn main() {
 //!   let v: Vec<u16> = "example".encode_utf16().collect();
@@ -42,7 +42,7 @@ macro_rules! imp {
             use $crate::internals::core::prelude::v1::*;
             const ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_LEN: usize =
               $crate::internals::length_as_utf16(ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF8) + $n;
-            const ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF16: [u16; ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_LEN] = {
+            const ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF16: &'static [u16; ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_LEN] = {
               let mut buffer = [0u16; ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_LEN];
               let mut bytes = ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF8.as_bytes();
               let mut i = 0;
@@ -59,7 +59,7 @@ macro_rules! imp {
                   i += 2;
                 }
               }
-              buffer
+              &{ buffer }
             };
             ABC678_PREFIX_THAT_SHOULD_NEVER_CLASH_WITH_OUTER_SCOPE_UTF16
           }
@@ -70,13 +70,13 @@ macro_rules! imp {
 }
 
 imp! {
-  /// Turns a string literal into a `u16` array literal (`[u16; N]`).
+  /// Turns a string literal into a `u16` array literal static reference (`&'static [u16; N]`).
   ///
   /// If you want to have a "null terminated" string (such as for some parts of
   /// Windows FFI) then you should use [`utf16_null!`](utf16_null!).
   utf16 has 0 trailing zeroes
 
-  /// Turns a string literal into a `u16` array literal (`[u16; N]`) with a trailing `0`.
+  /// Turns a string literal into a `u16` array literal static reference (`&'static [u16; N]`) with a trailing `0`.
   ///
   /// If you do **not** want to have a null terminator added to the string then
   /// you should use [`utf16!`](utf16!).

--- a/tests/utf16.rs
+++ b/tests/utf16.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use utf16_lit::utf16;
 
 #[test]

--- a/tests/utf16_null.rs
+++ b/tests/utf16_null.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use utf16_lit::utf16_null;
 
 #[test]


### PR DESCRIPTION
Based on https://github.com/Lokathor/utf16_lit/issues/13, the macro could be deemed slightly footgunny since it doesn't necessarily yield a `&'static` reference, and thus, _if bound to a local variable and then an `.as_ptr()` were to be taken to it_, then such a pointer would eventually dangle.

So, while I agree that this is kind of a non-issue (if one does a `.as_ptr()` on a local variable, they ought, at the very least, to type-annotate stuff precisely to make sure the obtained raw pointer is as valid as the user expects it to be), and while having to release yet another breaking change could be deemed annoying, truth be told, the only issue with another breaking change would be the code bloat of potentially having versions `2` and `3` within a dependency tree. But since this crate is so small, I don't think such code bloat matters enough to deter featuring this tiny improvement. Fixes #13.

Tangentially, the macro has been made more robust to call-sites where some prelude items could have been shadowed.

Finally, some `forbid(unsafe_code)` as per the safety-dance recommendation 🙂 

## Reviewing this

Since the first commit involves a lot of whitespace change, I recommend looking at the diff with the whitespace changes hidden:

 - https://github.com/Lokathor/utf16_lit/pull/14/files?diff=split&w=1